### PR TITLE
ADD mayadata-io branch to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,23 +5,18 @@ services:
 
 language: go
 
+go_import_path: github.com/kiali/kiali
+
 go:
 - 1.9.4
 
-notifications:
-  irc:
-    channels:
-      - chat.freenode.net#kiali
-    on_success: change
-    on_failure: change
+env:
+  global:
+    - COMMIT=${TRAVIS_COMMIT::6}
 
 before_script:
   - GO_FILES=$(find . -iname '*.go' -type f | grep -v /vendor/) # All the .go files, excluding vendor/
 
-env:
-  global:
-  - secure: "qy2ptBm0rm1gu2tWGRYZVB+IGy2aJXz40lrTbh/v01kE/iauK7knUYlpY4hkHBR8tTuvmDipHJJZSPhQrGLiLJU7+lSlr4X2pBJbou+hGal0pPlio379Bn3UZ0RTPE1kw8E6e007gGEcTQmFDeOCxQ1Rtm426guaL4SnXBM5D3dtQqEVhkgYGjivnOl2wrrqz1gBF/76OUfCN4nTwhJqiyiM/ELX3hYQ7CZcRQ7sZ+RqXEpR6zum+tgGauQ7zO+ebWKGn76ZaInZ4hnTx/hoiBmQ5jm6vOpOK2+Vqrskleh8QUvSRk1p1qjjUDj0gqgX2NoxqTrqSb6kMjez3hJCCz8teibuDBNqmER/mSoTFZQhMZYKwnUSe+xM9O+O2gOgNTwdm0Ejj1cY28BH02YiondG0mrX+xplFyzsDXOPdUdQdkT2YNfy29LI7fd2knWT294TPmbrYeoRqb4sQ76d+8RSJlgFpjkR8ejJT/aW3mzwO76YdJQXhuYM9JZx14whMIxWHi0Pje3/PgV7RfceyxbFs9dSaaZ5GYv8dvEsiIkTFgpEVdP45eL8VXj/6ErapjU2YYB9qzTgb+rvTPqqyP3GN3U6nd9Kd768DZvrzT6jCoua/m3lWnBiLFZXofOB9SomqaWv81VcUSIvr2uDpVl+onFBBx3C3RZM70PV5Jg="
-  - secure: "gYC5NDHZBMmTIPVzxXwZBFJ99UFnrnqN9YTNz3OxrN1qSrWi3g4nNhP2lyreKhaAg5IchYvHwjgktWYE25yCvsMLfaQQXw/2wCwRnEpcMDsVzZxVfExvy8bukhKlgKr8PXU+4mMTo1E+4b+HWdCTMQf0hKt6/7ccF8udY+VxXqQ6Kg9CrRSg3MtsMJR75rOUpJ2KgNG9N5GzCNl3hxwM+F7DpHEp0YstpAWqlugTHhsKGXEUfu/DGhRWfEmQnj0u8ra3qkjsRlanLcWdCfHR4lqPVuRRkeIP3QQkgJe283xVgt6t1sIUdMOSvoSqi+T469WI+nuO9ssPBikViQSc1P2vOay1p3dIx8PKmIvRlDr+fT5d8FvTafWCDMHOrAEJ3drkbjuMo/E3OXNq3QS8aXlFc17raa+gxihSQNVV1weyifng9+IO5JRoi1B9unOwuAl71Xt34uMAjCWJ2tZS/w4c5IPUaSlaXO4ULEgn0YEjxFnrroxBexFkWlgnT8wrjOg3JUOSbNSB1X81IoSEYiDg+Ddt/zn8lS0fQwAMvsuAODdY5EnMbLFDUKOEZxMl6GVAvDzp0LxGfzFLlHTGkPBy92Ox/59qRLXVvUcCn++Dl9TvnI5g8mSTcWjmDDHyTSShzfO/y/+aMc2mQ/OEYZ7u5o8qHOgeqFjrzHN72P0="
 
 # The project committed the vendor directory into source so there is no need for
 # travis to install dep and pull down dependencies.
@@ -29,13 +24,23 @@ env:
 # decided to no longer commit vendor dependencies into the source tree.
 # See: https://github.com/golang/dep/blob/master/docs/FAQ.md#should-i-commit-my-vendor-directory
 install:
+ - ./build-script.sh
  - make dep-install
  - make swagger-install
  - make gometalinter-install
-#- make dep-update
+# - make dep-update
 
 script:
   - if [ ! -z "$(gofmt -l ${GO_FILES})" ]; then echo "These files need to be formatted:" "$(gofmt -l ${GO_FILES})";echo "Diff files:"; gofmt -d ${GO_FILES}; exit 1; fi # Gofmt Linter
   - make lint
   - make clean build test-race
   - make swagger-travis
+  - make build
+  - cp ${GOPATH}/bin/kiali ./
+  - cd ..
+  - docker build -t mayadataio/kiali:$COMMIT -f ./kiali/Dockerfile .
+after_success:
+- if [ "$TRAVIS_BRANCH" = "mayadata-io" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then export REPO=mayadataio/kiali;
+   docker login -u "$DOCKER_USER" -p "$DOCKER_PASS" && ls -ltr && cd .. && docker build  -t $REPO:v1.11.0 -f ./kiali/Dockerfile . && docker push $REPO:v1.11.0;
+  fi
+  

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Stage 0, "build-stage", based on Node.js, to build and compile the frontend
+FROM node:10.8.0 as build-forntend
+WORKDIR /app
+#COPY package*.json /app/
+COPY ./kiali-ui /app/
+ENV NODE_OPTIONS=--max_old_space_size=4096
+RUN npm install -g yarn
+RUN yarn
+RUN yarn build
+RUN ls -ltr
+
+#COPY --from=build-stage /app/dist/out/ /usr/share/nginx/html
+#stage 2, copy forntend dist and go binary
+FROM centos:centos7
+
+LABEL maintainer="kiali-dev@googlegroups.com"
+
+ENV KIALI_HOME=/opt/kiali \
+    PATH=$KIALI_HOME:$PATH
+RUN echo $GOPATH
+WORKDIR $KIALI_HOME
+COPY ./kiali/kiali $KIALI_HOME/
+
+RUN mkdir $KIALI_HOME/console/
+
+COPY --from=build-forntend /app/build/ $KIALI_HOME/console/
+
+RUN chgrp -R 0 $KIALI_HOME/console && \
+    chmod -R g=u $KIALI_HOME/console
+
+ENTRYPOINT ["/opt/kiali/kiali"]

--- a/build-script.sh
+++ b/build-script.sh
@@ -1,0 +1,15 @@
+echo pwd
+KIALI_PATH=pwd
+echo $KIALI_PATH
+echo $GOPATH
+echo $GO_BUILD_ENVVARS
+# build kiali-ui
+export NODE_OPTIONS=--max_old_space_size=4096
+cd ../
+git clone https://github.com/mayadata-io/kiali-ui.git
+cd kiali-ui/
+NODE_OPTIONS=--max_old_space_size=4096
+git checkout mayadata-io
+ls -ltr
+cd ../kiali
+ls -ltr


### PR DESCRIPTION
** Describe the change **

The purpose of this Pr is to perform the build for the branch
`mayadata-io`

- build-script.sh  >> will clone mayadata-io/kiali-ui and checkout to
mayadata-io branch

- Dockerfile >> it is multistage build where it build the kiali-ui and
pass it to kiali container and copy the kiali binary to kiali container

- Travis >> it go back to one directory so that it
can access the kiali-ui and kiali folder and `run docker build ` below is the
ref for building the docker form one directory backwards
`https://stackoverflow.com/questions/24537340/docker-adding-a-file-from-a-parent-directory`
  - if the branch it mayadata-io it will push the image  to docker registry otherwise it will not push

Signed-off-by: inyee786 <intakhab.ali@mayadata.io>


** Backwards incompatible? **

Rebase the code with mayadata-io always

